### PR TITLE
Fix wrong function name for local mods

### DIFF
--- a/local.py
+++ b/local.py
@@ -1,7 +1,7 @@
 import os
 import shutil
 
-def scan(d):
+def mods(d):
     mods = []
     scan = [os.path.join(d,o) for o in os.listdir(d) if os.path.isdir(os.path.join(d,o))]
     for m in scan:


### PR DESCRIPTION
References in two places from `launch.py`

https://github.com/BrettMayson/Arma3Server/blob/911ff5f57f805e2c2cca6879a177b242f4b9e9d0/launch.py#L41

https://github.com/BrettMayson/Arma3Server/blob/911ff5f57f805e2c2cca6879a177b242f4b9e9d0/launch.py#L93