### PR TITLE
Allow building docker image via docker compose file

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -3,12 +3,18 @@ name: Docker Image CI
 on: [push, pull_request]
 
 jobs:
-
-  build:
- 
+  docker:
     runs-on: ubuntu-latest
- 
     steps:
     - uses: actions/checkout@v1
     - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag arma3server:$(date +%s)
+      run: docker build . --tag arma3server:$(date +%s)
+
+  docker-compose:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Copy .env file
+      run: cp .env.example .env
+    - name: Build the Docker image
+      run: docker-compose build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,9 @@
 version: '3.8'
 services:
   arma3:
+    build: .
     image: synixebrett/arma3server
+    platform: linux/amd64
     container_name: arma3
     network_mode: host
     volumes:


### PR DESCRIPTION
Can be built via `docker-compose build` or `docker compose build`

The platform declaration allows for building via buildx on non x86 platforms such as Raspberry Pi or Apple M1 arm64