### PR TITLE
Implemented option to provide steam guard code

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Profiles are saved in `/arma3/configs/profiles`
 | `-e STEAM_BRANCH_PASSWORD`    | Steam branch password used by steamcmd |
 | `-e STEAM_USER`               | Steam username used to login to steamcmd |
 | `-e STEAM_PASSWORD`           | Steam password |
+| `-e STEAM_GUARD_CODE`         | Steam guard code sent by email, it is one time only as per [Steam](https://developer.valvesoftware.com/wiki/SteamCMD#With_a_Steam_account)|
 | `-e HEADLESS_CLIENTS`         | Launch n number of headless clients                       | `0` |
 | `-e MODS_LOCAL`               | Should the mods folder be loaded | `true` |
 | `-e MODS_PRESET`              | An Arma 3 Launcher preset to load |

--- a/launch.py
+++ b/launch.py
@@ -28,6 +28,8 @@ steamcmd = ["/steamcmd/steamcmd.sh"]
 steamcmd.extend(["+login", os.environ["STEAM_USER"], os.environ["STEAM_PASSWORD"]])
 steamcmd.extend(["+force_install_dir", "/arma3"])
 steamcmd.extend(["+app_update", "233780"])
+if env_defined("STEAM_GUARD_CODE"):
+    steamcmd.extend(["+set_steam_guard_code", os.environ["STEAM_GUARD_CODE"]])
 if env_defined("STEAM_BRANCH_PASSWORD"):
     steamcmd.extend(["-beta", os.environ["STEAM_BRANCH"]])
 if env_defined("STEAM_BRANCH_PASSWORD"):


### PR DESCRIPTION
I have run into the issue that the account despite having Steam Guard off required steam guard code.

As referenced [here](https://developer.valvesoftware.com/wiki/SteamCMD#With_a_Steam_account) it is a one-time thing so it can be well incorporated.

It used a command described [here](https://developer.valvesoftware.com/wiki/Command_Line_Options#Commands_2), `set_steam_guard_code`.

I believe this can make life easier.