### PR TITLE
Remove Arma directory from mod path on load and rename files after download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update \
         lib32stdc++6 \
         lib32gcc1 \
         wget \
+        rename \
         ca-certificates \
     && \
     apt-get remove --purge -y \

--- a/launch.py
+++ b/launch.py
@@ -7,7 +7,7 @@ import workshop
 
 
 def mod_param(name, mods):
-    return ' -{}="{}" '.format(name, ";".join(mods))
+    return ' -{}="{}" '.format(name, ";".join(mods)).replace('/arma3/', '')
 
 
 def env_defined(key):

--- a/workshop.py
+++ b/workshop.py
@@ -9,8 +9,10 @@ LOCAL = "/arma3/mods/"
 WORKSHOP = "/arma3/steamapps/workshop/content/107410/"
 USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.47 Safari/537.36"  # noqa: E501
 
+def lowercase_workshop_dir(path: str):
+    os.system("(cd {} && find . -depth -exec rename -v 's/(.*)\/([^\/]*)/$1\/\L$2/' {{}} \;)".format(path))
 
-def mod(id):
+def download_mod(id):
     steamcmd = ["/steamcmd/steamcmd.sh"]
     steamcmd.extend(["+login", os.environ["STEAM_USER"], os.environ["STEAM_PASSWORD"]])
     steamcmd.extend(["+force_install_dir", "/arma3"])
@@ -35,8 +37,9 @@ def preset(mod_file):
         regex = r"filedetails\/\?id=(\d+)\""
         matches = re.finditer(regex, html, re.MULTILINE)
         for _, match in enumerate(matches, start=1):
-            mod(match.group(1))
+            download_mod(match.group(1))
             moddir = WORKSHOP + match.group(1)
+            lowercase_workshop_dir(moddir)
             mods.append(moddir)
             keys.copy(moddir)
     return mods


### PR DESCRIPTION
Mod paths are required to be under the arma3 directory with relative paths given to the executable. Linux is also case sensitive so we need to rename all mods downloaded lowercase or arma3 will fail to load. 

See: [Issue loading mods using HTML from launcher](#38) as I had this same issue.
