### PR TITLE
FIX: Mod not loaded when workshop is used

### DIFF
--- a/workshop.py
+++ b/workshop.py
@@ -5,8 +5,7 @@ import urllib.request
 
 import keys
 
-LOCAL = "/arma3/mods/"
-WORKSHOP = "/arma3/steamapps/workshop/content/107410/"
+WORKSHOP = "steamapps/workshop/content/107410/"
 USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.47 Safari/537.36"  # noqa: E501
 
 


### PR DESCRIPTION
fix #38 by using relative path as done for local mod:
https://github.com/BrettMayson/Arma3Server/blob/e777a7209b0179dcf3fe5e2caed6978d37962264/launch.py#L46

Also remove `LOCAL` as not used. Also a little confusing as local mods are handle by local.py.