### PR TITLE
Use glob for gathering workshop keys

### DIFF
--- a/keys.py
+++ b/keys.py
@@ -1,13 +1,18 @@
 import os
+import glob
 import shutil
 
 
 def copy(moddir):
-    keysdir = os.path.join(moddir, "keys")
-    if os.path.exists(keysdir):
-        for o in os.listdir(keysdir):
-            keyfile = os.path.join(keysdir, o)
-            if not os.path.isdir(keyfile):
-                shutil.copy2(keyfile, "/arma3/keys")
+    keys = glob.glob(os.path.join(moddir, '**/*.bikey'))
+    if len(keys) > 0:
+        for key in keys:
+            if not os.path.isdir(key):
+                shutil.copy2(key, "/arma3/keys")
     else:
-        print("Missing keys:", keysdir)
+        print("Missing keys:", moddir)
+
+
+if __name__ == '__main__':
+    for moddir in glob.glob("/arma3/steamapps/workshop/content/107410/*"):
+        copy(moddir)

--- a/keys.py
+++ b/keys.py
@@ -4,7 +4,7 @@ import shutil
 
 
 def copy(moddir):
-    keys = glob.glob(os.path.join(moddir, '**/*.bikey'))
+    keys = glob.glob(os.path.join(moddir, "**/*.bikey"))
     if len(keys) > 0:
         for key in keys:
             if not os.path.isdir(key):
@@ -13,6 +13,6 @@ def copy(moddir):
         print("Missing keys:", moddir)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     for moddir in glob.glob("/arma3/steamapps/workshop/content/107410/*"):
         copy(moddir)


### PR DESCRIPTION
Potential solution for #45 which seems to pick all up the keys for my use case.  

Added the `__name__ == '__main__'`  just so it can be ran as a script if something goes wrong without needing to go through `launch.py` again. 