### PR TITLE
Install libcurl4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update \
         python3 \
         lib32stdc++6 \
         lib32gcc-s1 \
+        libcurl4 \
         wget \
         ca-certificates \
     && \


### PR DESCRIPTION
Required for OCAP, but could be useful for other extensions as well.

I am not sure if we want to satisfy common extension requirements or not @BrettMayson?