### PR TITLE
Avoid login in for every seperate mod

### DIFF
--- a/workshop.py
+++ b/workshop.py
@@ -9,11 +9,12 @@ WORKSHOP = "steamapps/workshop/content/107410/"
 USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.47 Safari/537.36"  # noqa: E501
 
 
-def mod(id):
+def download(mods):
     steamcmd = ["/steamcmd/steamcmd.sh"]
     steamcmd.extend(["+force_install_dir", "/arma3"])
     steamcmd.extend(["+login", os.environ["STEAM_USER"], os.environ["STEAM_PASSWORD"]])
-    steamcmd.extend(["+workshop_download_item", "107410", id])
+    for id in mods:
+        steamcmd.extend(["+workshop_download_item", "107410", id])
     steamcmd.extend(["+quit"])
     subprocess.call(steamcmd)
 
@@ -29,13 +30,16 @@ def preset(mod_file):
             f.write(remote.read())
         mod_file = "preset.html"
     mods = []
+    moddirs = []
     with open(mod_file) as f:
         html = f.read()
         regex = r"filedetails\/\?id=(\d+)\""
         matches = re.finditer(regex, html, re.MULTILINE)
         for _, match in enumerate(matches, start=1):
-            mod(match.group(1))
+            mods.append(match.group(1))
             moddir = WORKSHOP + match.group(1)
-            mods.append(moddir)
+            moddirs.append(moddir)
+        download(mods)
+        for moddir in moddirs:
             keys.copy(moddir)
     return mods


### PR DESCRIPTION
Login in on every seperate mod of a preset can cause Rate limits with big presets.