### PR TITLE
Return correct list of mod dirs

### DIFF
--- a/workshop.py
+++ b/workshop.py
@@ -42,4 +42,4 @@ def preset(mod_file):
         download(mods)
         for moddir in moddirs:
             keys.copy(moddir)
-    return mods
+    return moddir

--- a/workshop.py
+++ b/workshop.py
@@ -42,4 +42,4 @@ def preset(mod_file):
         download(mods)
         for moddir in moddirs:
             keys.copy(moddir)
-    return moddir
+    return moddirs


### PR DESCRIPTION
After changes in #58 , forgot to change return var to the correct moddir list instead of just a list of mod ID's.