### PR TITLE
Use PORT environment variable for headless clients

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -104,7 +104,7 @@ if clients != 0:
         launch += ' -config="/tmp/arma3.cfg"'
 
     client_launch = launch
-    client_launch += " -client -connect=127.0.0.1"
+    client_launch += " -client -connect=127.0.0.1 -port={}".format(os.environ["PORT"])
     if "password" in config_values:
         client_launch += " -password={}".format(config_values["password"])
 


### PR DESCRIPTION
Currently headless clients attempt to connect to a server running listening on the default port 2302, which can fail if the server has been configured to listen elsewhere.

This change adds the port flag to the client launch command.