### PR TITLE
Fixed: lots of anonymous volumes was left behind, at every restart.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,5 +11,22 @@ services:
       - './configs:/arma3/configs'
       - './mods:/arma3/mods'
       - './servermods:/arma3/servermods'
+      - 'addons:/arma3/addons'
+      - 'argo:/arma3/argo'
+      - 'enoch:/arma3/enoch'
+      - 'expansion:/arma3/expansion'
+      - 'heli:/arma3/heli'
+      - 'jets:/arma3/jets'
+      - 'orange:/arma3/orange'
+      - 'steamcmd:/steamcmd'
     env_file: .env
     restart: unless-stopped
+volumes:
+  addons:
+  argo:
+  enoch:
+  expansion:
+  heli:
+  jets:
+  orange:
+  steamcmd:


### PR DESCRIPTION
Unfortunately, if we don't connect something to the VOLUMES listed in the Dockerfile, then every restart leaves behind a set of "anonymous" volumes, which just take up disk space.

Ones left behind before this change can be cleaned up by running `docker volume prune -af`.