### PR TITLE
Add support for OCAP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,14 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get update \
     && \
     apt-get install -y --no-install-recommends --no-install-suggests \
-        python3 \
-        lib32stdc++6 \
-        lib32gcc-s1 \
-        libcurl4 \
-        wget \
-        ca-certificates \
+    python3 \
+    lib32stdc++6 \
+    lib32gcc-s1 \
+    libcurl4 \
+    wget \
+    ca-certificates \
+    curl \
+    libstdc++6 \
     && \
     apt-get remove --purge -y \
     && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,14 +7,14 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get update \
     && \
     apt-get install -y --no-install-recommends --no-install-suggests \
-    python3 \
-    lib32stdc++6 \
-    lib32gcc-s1 \
-    libcurl4 \
-    wget \
-    ca-certificates \
-    curl \
-    libstdc++6 \
+        python3 \
+        lib32stdc++6 \
+        lib32gcc-s1 \
+        libcurl4 \
+        wget \
+        ca-certificates \
+        curl \
+        libstdc++6 \
     && \
     apt-get remove --purge -y \
     && \


### PR DESCRIPTION
curl and libstdc++6 are needed within the image for the ocap extension to work.