### PR TITLE
Remove now-redundant volume definitions in compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,12 +13,3 @@ services:
       - './server:/arma3/server/'
     env_file: .env
     restart: unless-stopped
-volumes:
-  addons:
-  argo:
-  enoch:
-  expansion:
-  heli:
-  jets:
-  orange:
-  steamcmd:


### PR DESCRIPTION
Revert #82 because db0ebb2c2d070b7f9f8503b9a8252dc7dcfc47ea changed the way this is handled.