### PR TITLE
Add libavahi to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update \
         libssl3 \
         libc6 \
         git \
+        libavahi-client3 \
     && \
     apt-get remove --purge -y \
     && \


### PR DESCRIPTION
Linux Dedicated server now requires libavahi-common/libavahi-client since Perf/Prof v78
the debian-slim base used does not have it by default

 https://community.bistudio.com/wiki/Arma_3:_Prof-Branch_Change_Log_v2.20#22-07-2026